### PR TITLE
EN-465: Remove data source from module intended to be dynamic

### DIFF
--- a/modules/azure-key-vault-access-policy/main.tf
+++ b/modules/azure-key-vault-access-policy/main.tf
@@ -6,11 +6,9 @@ terraform {
   required_version = ">= 0.12"
 }
 
-data "azurerm_client_config" "current" {}
-
 resource "azurerm_key_vault_access_policy" "policy" {
   key_vault_id   = var.key_vault_id
-  tenant_id      = data.azurerm_client_config.current.tenant_id
+  tenant_id      = var.tenant_id
   object_id      = var.object_id
   application_id = var.application_id
 

--- a/modules/azure-key-vault-access-policy/vars.tf
+++ b/modules/azure-key-vault-access-policy/vars.tf
@@ -37,3 +37,8 @@ variable "storage_permissions" {
   type        = set(string)
   default     = []
 }
+
+variable "tenant_id" {
+  description = "The tenant ID in which the principals being attached to this policy exist."
+  type        = string
+}


### PR DESCRIPTION
Removing the nested data source to avoid a permadiff when the module is used inside of a dynamic context (such as a `for_each` or `count`). Because the inputs to the module aren't definitively known, Terraform treats the outputs of the data source as unknown (even though there are no inputs bound to it). This causes the `tenant_id` not to be known until after the apply, which forces an update which in this case is a destroy/create.

Instead we'll use the data source in a non-dynamic portion of the super module and pass its output as a primitive string to the module. This does however break existing implementations and is marked as such.