### PR TITLE
EN-465: Remove deprecated property that causes a premadiff

### DIFF
--- a/modules/azure-key-vault/main.tf
+++ b/modules/azure-key-vault/main.tf
@@ -20,7 +20,6 @@ resource "azurerm_key_vault" "key_vault" {
   enabled_for_disk_encryption     = var.enabled_for_disk_encryption
   enabled_for_template_deployment = var.enabled_for_template_deployment
   purge_protection_enabled        = var.purge_protection_enabled
-  soft_delete_enabled             = var.soft_delete_enabled
 
   # Note that this module doesn't support inlining an access policy.
   # We recommend always using the separate `azurerm_key_vault_access_policy` resource.

--- a/modules/azure-key-vault/vars.tf
+++ b/modules/azure-key-vault/vars.tf
@@ -67,12 +67,6 @@ variable "purge_protection_enabled" {
   default     = false
 }
 
-variable "soft_delete_enabled" {
-  description = "Whether or not soft delete is enabled for this key vault."
-  type        = bool
-  default     = false
-}
-
 variable "tags" {
   description = "A mapping of tags to assign to this resource."
   type        = map(string)


### PR DESCRIPTION
The property `soft_delete_enabled` was deprecated by the upstream Azure API which now only allows for that setting to be enabled (you cannot disable soft deletion as of 15 December 2020). As a result there is a residual diff that conflicts with the default behaviour of this module:

```
~ soft_delete_enabled             = true -> false
```

By removing it from the module and allowing the provider/resource's default behaviour, this diff is avoided.