### PR TITLE
XDR-883: Update infrastructure-module ref to current tag

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,6 @@ jobs:
           parameters:
             name: UpdateInfrastructureModules
             displayName: Update Infrastructure Modules
-            srcRepository: package-azure-key-vault.git
-            dstRepository: infrastructure-modules
+            packageName: package-azure-key-vault
+            repository: infrastructure-modules
             condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))


### PR DESCRIPTION
- Uses `LATEST_VERSION` from https://github.com/quantum-sec/pipeline-library/blob/bf08c840c2d1a3c0343220392e0586585f5377af/templates/steps/utilities/verify-version-changed.yml#L20
 - output from `git describe --tags --abbrev=0`
- Replaces all lines including `srcRepository` to set the `ref=` to the value from `LATEST_VERSION`